### PR TITLE
Minor syntax fixes.

### DIFF
--- a/Adafruit_seesawPeripheral.h
+++ b/Adafruit_seesawPeripheral.h
@@ -88,6 +88,7 @@ void foo(void);
 
 #if defined(ARDUINO_AVR_ATtiny817) || defined(ARDUINO_AVR_ATtiny807) ||        \
     defined(ARDUINO_AVR_ATtiny1617) || defined(ARDUINO_AVR_ATtiny1607) ||      \
+    defined(ARDUINO_AVR_ATtiny427) || defined(ARDUINO_AVR_ATtiny827) ||      \
     defined(ARDUINO_AVR_ATtiny3217)
 #define UART_DEBUG_RXD 8
 #define UART_DEBUG_TXD 9
@@ -122,6 +123,7 @@ void foo(void);
 
 #if defined(ARDUINO_AVR_ATtiny817) || defined(ARDUINO_AVR_ATtiny807) ||        \
     defined(ARDUINO_AVR_ATtiny1617) || defined(ARDUINO_AVR_ATtiny1607) ||      \
+    defined(ARDUINO_AVR_ATtiny427) || defined(ARDUINO_AVR_ATtiny827) ||      \
     defined(ARDUINO_AVR_ATtiny3217)
 #define ALL_GPIO                                                               \
   0x1FFFFFUL // this is chip dependant, for 817 we have 21 GPIO avail (0~20 inc)

--- a/Adafruit_seesawPeripheral_main.h
+++ b/Adafruit_seesawPeripheral_main.h
@@ -7,9 +7,11 @@ volatile uint32_t g_currentGPIO = 0, g_lastGPIO = 0;
 #endif
 
 #if USE_PINCHANGE_INTERRUPT
+void Adafruit_seesawPeripheral_pinChangeDetect(void);
+
 void Adafruit_seesawPeripheral_changedGPIO(void) {
   SEESAW_DEBUG(F("Change IRQ"));
-  Adafruit_seesawPeripheral_pinChangeDetect()
+  Adafruit_seesawPeripheral_pinChangeDetect();
 }
 #endif
 


### PR DESCRIPTION
I actually don't think the changes to Adafruit_seesawPeripheral.h need to be in your code, but I think they're correct.  They are likely also missing the 1627, 3227, and your previoud ones are missing the 417.

So, maybe ignore the changes to Adafruit_seesawPeripheral.h

But, I think the change to Adafruit_seesawPeripheral_main.h is necessary for anyone that wants to use USE_PINCHANGE_INTERRUPT

It is mainly adding a missed semicolon and a function prototype.

