### PR TITLE
Add encoder support

### DIFF
--- a/Adafruit_seesawPeripheral.h
+++ b/Adafruit_seesawPeripheral.h
@@ -206,6 +206,30 @@ volatile uint8_t g_neopixel_bufsize = 0;
 volatile uint8_t g_neopixel_pin = 0;
 #endif
 
+#if CONFIG_ENCODER
+
+#define BIT_IS_SET(x,b) (((x)&(1UL << b)) != 0)
+#define BIT_IS_CLEAR(x,b) (((x)&(1UL << b)) == 0)
+
+#define ENCODER0_INPUT_MASK ((1UL << CONFIG_ENCODER0_A_PIN) | (1UL << CONFIG_ENCODER0_B_PIN))
+
+#ifdef CONFIG_ENCODER1_A_PIN
+#define ENCODER1_INPUT_MASK ((1UL << CONFIG_ENCODER1_A_PIN) | (1UL << CONFIG_ENCODER1_B_PIN))
+#endif
+#ifdef CONFIG_ENCODER2_A_PIN
+#define ENCODER2_INPUT_MASK ((1UL << CONFIG_ENCODER2_A_PIN) | (1UL << CONFIG_ENCODER2_B_PIN))
+#endif
+#ifdef CONFIG_ENCODER3_A_PIN
+#define ENCODER3_INPUT_MASK ((1UL << CONFIG_ENCODER3_A_PIN) | (1UL << CONFIG_ENCODER3_B_PIN))
+#endif
+
+volatile int32_t g_enc_value[CONFIG_NUM_ENCODERS];
+volatile int32_t g_enc_delta[CONFIG_NUM_ENCODERS];
+volatile uint8_t g_enc_prev_pos[CONFIG_NUM_ENCODERS];
+volatile uint8_t g_enc_flags[CONFIG_NUM_ENCODERS];
+
+#endif
+
 /****************************************************** code */
 
 // global address
@@ -329,6 +353,39 @@ void Adafruit_seesawPeripheral_reset(void) {
     g_neopixel_buf[i] = 0;
   }
   g_neopixel_bufsize = 0;
+#endif
+#if CONFIG_ENCODER
+#if defined(CONFIG_ENCODER0_A_PIN)
+  pinMode(CONFIG_ENCODER0_A_PIN, INPUT_PULLUP);
+#endif
+#if defined(CONFIG_ENCODER0_B_PIN)
+  pinMode(CONFIG_ENCODER0_B_PIN, INPUT_PULLUP);
+#endif
+#if defined(CONFIG_ENCODER1_A_PIN)
+  pinMode(CONFIG_ENCODER1_A_PIN, INPUT_PULLUP);
+#endif
+#if defined(CONFIG_ENCODER1_B_PIN)
+  pinMode(CONFIG_ENCODER1_B_PIN, INPUT_PULLUP);
+#endif
+#if defined(CONFIG_ENCODER2_A_PIN)
+  pinMode(CONFIG_ENCODER2_A_PIN, INPUT_PULLUP);
+#endif
+#if defined(CONFIG_ENCODER2_B_PIN)
+  pinMode(CONFIG_ENCODER2_B_PIN, INPUT_PULLUP);
+#endif
+#if defined(CONFIG_ENCODER3_A_PIN)
+  pinMode(CONFIG_ENCODER3_A_PIN, INPUT_PULLUP);
+#endif
+#if defined(CONFIG_ENCODER3_B_PIN)
+  pinMode(CONFIG_ENCODER3_B_PIN, INPUT_PULLUP);
+#endif
+
+  for (uint8_t encodernum=0; encodernum<CONFIG_NUM_ENCODERS; encodernum++) {
+    g_enc_value[CONFIG_NUM_ENCODERS] = 0;
+    g_enc_delta[CONFIG_NUM_ENCODERS] = 0;
+    g_enc_prev_pos[CONFIG_NUM_ENCODERS] = 0;
+    g_enc_flags[CONFIG_NUM_ENCODERS] = 0;
+  }
 #endif
 
 #if CONFIG_FHT && defined(MEGATINYCORE)

--- a/Adafruit_seesawPeripheral.h
+++ b/Adafruit_seesawPeripheral.h
@@ -381,10 +381,10 @@ void Adafruit_seesawPeripheral_reset(void) {
 #endif
 
   for (uint8_t encodernum=0; encodernum<CONFIG_NUM_ENCODERS; encodernum++) {
-    g_enc_value[CONFIG_NUM_ENCODERS] = 0;
-    g_enc_delta[CONFIG_NUM_ENCODERS] = 0;
-    g_enc_prev_pos[CONFIG_NUM_ENCODERS] = 0;
-    g_enc_flags[CONFIG_NUM_ENCODERS] = 0;
+    g_enc_value[encodernum] = 0;
+    g_enc_delta[encodernum] = 0;
+    g_enc_prev_pos[encodernum] = 0;
+    g_enc_flags[encodernum] = 0;
   }
 #endif
 

--- a/Adafruit_seesawPeripheral_main.h
+++ b/Adafruit_seesawPeripheral_main.h
@@ -29,6 +29,104 @@ void Adafruit_seesawPeripheral_pinChangeDetect(void) {
     pinMode(CONFIG_INTERRUPT_PIN, OUTPUT);
   }
 
+#if CONFIG_ENCODER
+    uint32_t mask = ENCODER0_INPUT_MASK;
+#ifdef ENCODER1_INPUT_MASK
+    mask |= ENCODER1_INPUT_MASK;
+#endif
+#ifdef ENCODER2_INPUT_MASK
+    mask |= ENCODER2_INPUT_MASK;
+#endif
+#ifdef ENCODER3_INPUT_MASK
+    mask |= ENCODER3_INPUT_MASK;
+#endif
+
+    uint32_t in = g_currentGPIO & mask;    
+
+    for (uint8_t encodernum=0; encodernum<CONFIG_NUM_ENCODERS; encodernum++) {
+
+      int8_t enc_action = 0; // 1 or -1 if moved, sign is direction
+
+      uint8_t enc_cur_pos = 0;
+      // read in the encoder state first
+      if (encodernum == 0) {
+        enc_cur_pos |= ((BIT_IS_CLEAR(in, CONFIG_ENCODER0_A_PIN)) << 0) | ((BIT_IS_CLEAR(in, CONFIG_ENCODER0_B_PIN)) << 1);
+      }
+#if defined(CONFIG_ENCODER1_A_PIN)
+      if (encodernum == 1) {
+        enc_cur_pos |= ((BIT_IS_CLEAR(in, CONFIG_ENCODER1_A_PIN)) << 0) | ((BIT_IS_CLEAR(in, CONFIG_ENCODER1_B_PIN)) << 1);      
+      }
+#endif
+#if defined(CONFIG_ENCODER2_A_PIN)
+      if (encodernum == 2) {
+        enc_cur_pos |= ((BIT_IS_CLEAR(in, CONFIG_ENCODER2_A_PIN)) << 0) | ((BIT_IS_CLEAR(in, CONFIG_ENCODER2_B_PIN)) << 1);      
+      }
+#endif
+#if defined(CONFIG_ENCODER3_A_PIN)
+      if (encodernum == 3) {
+        enc_cur_pos |= ((BIT_IS_CLEAR(in, CONFIG_ENCODER3_A_PIN)) << 0) | ((BIT_IS_CLEAR(in, CONFIG_ENCODER3_B_PIN)) << 1);      
+      }
+#endif
+
+      // if any rotation at all
+      if (enc_cur_pos != g_enc_prev_pos[encodernum])
+      {
+        if (g_enc_prev_pos[encodernum] == 0x00)
+        {
+          // this is the first edge
+          if (enc_cur_pos == 0x01) {
+            g_enc_flags[encodernum] |= (1 << 0);
+          }
+          else if (enc_cur_pos == 0x02) {
+            g_enc_flags[encodernum] |= (1 << 1);
+          }
+        }
+        
+        if (enc_cur_pos == 0x03)
+        {
+          // this is when the encoder is in the middle of a "step"
+          g_enc_flags[encodernum] |= (1 << 4);
+        }
+        else if (enc_cur_pos == 0x00)
+        {
+          // this is the final edge
+          if (g_enc_prev_pos[encodernum] == 0x02) {
+            g_enc_flags[encodernum] |= (1 << 2);
+          }
+          else if (g_enc_prev_pos[encodernum] == 0x01) {
+            g_enc_flags[encodernum] |= (1 << 3);
+          }
+          
+          // check the first and last edge
+          // or maybe one edge is missing, if missing then require the middle state
+          // this will reject bounces and false movements
+          if (BIT_IS_SET(g_enc_flags[encodernum], 0) && (BIT_IS_SET(g_enc_flags[encodernum], 2) || BIT_IS_SET(g_enc_flags[encodernum], 4))) {
+            enc_action = 1;
+          }
+          else if (BIT_IS_SET(g_enc_flags[encodernum], 2) && (BIT_IS_SET(g_enc_flags[encodernum], 0) || BIT_IS_SET(g_enc_flags[encodernum], 4))) {
+            enc_action = 1;
+          }
+          else if (BIT_IS_SET(g_enc_flags[encodernum], 1) && (BIT_IS_SET(g_enc_flags[encodernum], 3) || BIT_IS_SET(g_enc_flags[encodernum], 4))) {
+            enc_action = -1;
+          }
+          else if (BIT_IS_SET(g_enc_flags[encodernum], 3) && (BIT_IS_SET(g_enc_flags[encodernum], 1) || BIT_IS_SET(g_enc_flags[encodernum], 4))) {
+            enc_action = -1;
+          }
+          
+          g_enc_flags[encodernum] = 0; // reset for next time
+        }
+      }
+
+      g_enc_prev_pos[encodernum] = enc_cur_pos;
+      
+      if(enc_action != 0){
+        g_enc_value[encodernum] += enc_action;
+        g_enc_delta[encodernum] += enc_action;
+        
+      }
+    }
+#endif
+
   g_lastGPIO = g_currentGPIO;
 #endif
 }

--- a/Adafruit_seesawPeripheral_request.h
+++ b/Adafruit_seesawPeripheral_request.h
@@ -57,6 +57,26 @@ void requestEvent(void) {
   }
 #endif
 
+#if CONFIG_ENCODER
+  else if (base_cmd == SEESAW_ENCODER_BASE) {
+    uint8_t encoder_num = 0;
+    if (module_cmd >= SEESAW_ENCODER_POSITION && module_cmd < SEESAW_ENCODER_DELTA) {
+      encoder_num = module_cmd - SEESAW_ENCODER_POSITION;
+      if (encoder_num < CONFIG_NUM_ENCODERS){
+        Adafruit_seesawPeripheral_write32(g_enc_value[encoder_num]);
+        g_enc_delta[encoder_num] = 0;
+      }
+    }
+    else if (module_cmd >= SEESAW_ENCODER_DELTA) {
+      encoder_num = module_cmd - SEESAW_ENCODER_DELTA;
+      if (encoder_num < CONFIG_NUM_ENCODERS){
+        Adafruit_seesawPeripheral_write32(g_enc_delta[encoder_num]);
+        g_enc_delta[encoder_num] = 0;
+      }
+    }
+  }
+#endif
+
 #if CONFIG_FHT && defined(MEGATINYCORE)
   else if (base_cmd == SEESAW_SPECTRUM_BASE) {
     // TO DO: change to A/B/C/D results if we decide on FHT_N = 256.

--- a/examples/example_encoder/example_encoder.ino
+++ b/examples/example_encoder/example_encoder.ino
@@ -1,0 +1,43 @@
+#define PRODUCT_CODE            1234
+#define CONFIG_I2C_PERIPH_ADDR  0x49
+//#define CONFIG_UART_DEBUG          1
+
+#define CONFIG_INTERRUPT_PIN      15
+//#define USE_PINCHANGE_INTERRUPT    1
+
+// Can have up to 3 addresses
+#define CONFIG_ADDR_0_PIN          16
+#define CONFIG_ADDR_1_PIN          17
+
+#define CONFIG_ADC                 1
+#define CONFIG_PWM                 1
+#define CONFIG_NEOPIXEL            1
+#define CONFIG_NEOPIXEL_BUF_MAX   (60*3) // 30 pixels == 180 bytes
+
+//* ============== ENCODER =================== *//
+#define CONFIG_ENCODER 1
+#define CONFIG_NUM_ENCODERS 1
+#define CONFIG_ENCODER0_A_PIN 0
+#define CONFIG_ENCODER0_B_PIN 1
+//#define CONFIG_ENCODER1_A_PIN 2
+//#define CONFIG_ENCODER1_B_PIN 3
+//#define CONFIG_ENCODER2_A_PIN 5
+//#define CONFIG_ENCODER2_B_PIN 6
+//#define CONFIG_ENCODER3_A_PIN 7
+//#define CONFIG_ENCODER3_B_PIN 8
+
+#include "Adafruit_seesawPeripheral.h"
+
+void setup() {
+#if CONFIG_UART_DEBUG
+  Serial.begin(115200);
+  delay(500);
+#endif
+
+  Adafruit_seesawPeripheral_begin();
+}
+
+
+void loop() {
+  Adafruit_seesawPeripheral_run();
+}


### PR DESCRIPTION
This adds the ability to have up to 4 encoders. I tested this with 2 encoders attached to the [Adafruit ATtiny817 Breakout with seesaw](https://www.adafruit.com/product/5233) and a QT Py Haxpress using the following code based off of the [CircuitPython rotaryio example](https://github.com/adafruit/Adafruit_CircuitPython_seesaw/blob/main/examples/seesaw_simpletest.py). 

```py
import board
from adafruit_seesaw import seesaw, rotaryio

seesaw = seesaw.Seesaw(board.I2C(), addr=0x49)

seesaw_product = (seesaw.get_version() >> 16) & 0xFFFF
print("Found product {}".format(seesaw_product))
if seesaw_product != 1234:
    print("Wrong firmware loaded?  Expected 1234")

encoder1 = rotaryio.IncrementalEncoder(seesaw)
encoder2 = rotaryio.IncrementalEncoder(seesaw,encoder=1)

last_position1 = None
last_position2 = None

while True:

    position1 = encoder1.position
    position2 = encoder2.position

    if position1 != last_position1:
       last_position1 = position1
       print("Position 1: {}".format(position1))

    if position2 != last_position2:
       last_position2 = position2
       print("Position 2: {}".format(position2))

```