### PR TITLE
Add UART support and example

### DIFF
--- a/Adafruit_seesawPeripheral.h
+++ b/Adafruit_seesawPeripheral.h
@@ -207,6 +207,13 @@ volatile uint8_t g_neopixel_buf[CONFIG_NEOPIXEL_BUF_MAX];
 volatile uint16_t g_neopixel_bufsize = 0;
 volatile uint8_t g_neopixel_pin = 0;
 #endif
+#if CONFIG_UART
+volatile uint8_t g_uart_buf[CONFIG_UART_BUF_MAX];
+volatile uint8_t g_uart_status = 0;
+volatile uint8_t g_uart_inten = 0;
+volatile uint32_t g_uart_baud = 9600;
+volatile uint8_t g_uart_tx_len = 0;
+#endif
 
 /****************************************************** code */
 
@@ -254,7 +261,7 @@ void Adafruit_seesawPeripheral_clearIRQ(void) {
 }
 
 bool Adafruit_seesawPeripheral_begin(void) {
-  SEESAW_DEBUG(F("All GPIO: ")); 
+  SEESAW_DEBUG(F("All GPIO: "));
   SEESAW_DEBUGLN(ALL_GPIO, HEX);
   SEESAW_DEBUG(F("Invalid: "));
   SEESAW_DEBUGLN(INVALID_GPIO, HEX);
@@ -388,6 +395,10 @@ void Adafruit_seesawPeripheral_reset(void) {
   ADC0.SAMPCTRL = 12; // Add to usu. 13 ADC cycles for 25 cycles/sample
   ADC0.INTCTRL |= ADC_RESRDY_bm; // Enable result-ready interrupt
   ADC0.COMMAND |= ADC_STCONV_bm; // Start free-run conversion
+#endif
+
+#if CONFIG_UART
+  CONFIG_UART_SERCOM.begin(g_uart_baud);
 #endif
 
   Wire.begin(_i2c_addr);

--- a/Adafruit_seesawPeripheral_main.h
+++ b/Adafruit_seesawPeripheral_main.h
@@ -32,7 +32,7 @@ void Adafruit_seesawPeripheral_pinChangeDetect(void) {
 
 void Adafruit_seesawPeripheral_run(void) {
 #if CONFIG_INTERRUPT && ! USE_PINCHANGE_INTERRUPT
-  // we dont .need. to use the IRQ system which takes a lot of flash and 
+  // we dont .need. to use the IRQ system which takes a lot of flash and
   // doesn't uniquely identify pins anyways
   if (IRQ_debounce_cntr == 0) {
     Adafruit_seesawPeripheral_pinChangeDetect();
@@ -106,5 +106,18 @@ void Adafruit_seesawPeripheral_run(void) {
   TWI0.SCTRLA |= TWI_DIEN_bm | TWI_APIEN_bm | TWI_PIEN_bm;
 #endif // end CONFIG_FHT
 
+#if CONFIG_UART
+  if (g_uart_inten) {
+    if (CONFIG_UART_SERCOM.available()) {
+      Adafruit_seesawPeripheral_setIRQ();
+    } else {
+      Adafruit_seesawPeripheral_clearIRQ();
+    }
+  }
+  if (g_uart_tx_len > 0) {
+    CONFIG_UART_SERCOM.write((char *)g_uart_buf, (size_t)g_uart_tx_len);
+    g_uart_tx_len = 0;
+  }
+#endif
   // delay(10);
 }

--- a/Adafruit_seesawPeripheral_request.h
+++ b/Adafruit_seesawPeripheral_request.h
@@ -70,6 +70,23 @@ void requestEvent(void) {
   }
 #endif
 
+#if CONFIG_UART
+  else if (base_cmd == SEESAW_SERCOM0_BASE) {
+    if (module_cmd == SEESAW_SERCOM_STATUS) {
+      Wire.write(g_uart_status);
+    } else if (module_cmd == SEESAW_SERCOM_INTEN) {
+      Wire.write(g_uart_inten);
+    } else if (module_cmd == SEESAW_SERCOM_BAUD) {
+      Wire.write((g_uart_baud >> 24) & 0xFF);
+      Wire.write((g_uart_baud >> 16) & 0xFF);
+      Wire.write((g_uart_baud >> 8) & 0xFF);
+      Wire.write(g_uart_baud & 0xFF);
+    } else if (module_cmd == SEESAW_SERCOM_DATA) {
+      Wire.write(CONFIG_UART_SERCOM.read());
+    }
+  }
+#endif
+
   else {
     SEESAW_DEBUG(F("Unhandled cmd 0x"));
     SEESAW_DEBUGLN(base_cmd, HEX);

--- a/examples/example_uart/example_uart.ino
+++ b/examples/example_uart/example_uart.ino
@@ -1,0 +1,24 @@
+#define PRODUCT_CODE            1234
+#define CONFIG_I2C_PERIPH_ADDR  0x49
+//#define CONFIG_UART_DEBUG          1
+
+#define CONFIG_INTERRUPT_PIN       5
+
+// Can have up to 3 addresses
+#define CONFIG_ADDR_0_PIN          6
+#define CONFIG_ADDR_1_PIN          7
+
+#define CONFIG_UART                1
+#define CONFIG_UART_BUF_MAX       32
+#define CONFIG_UART_SERCOM    Serial
+
+#include "Adafruit_seesawPeripheral.h"
+
+void setup() {
+  Adafruit_seesawPeripheral_begin();
+}
+
+
+void loop() {
+  Adafruit_seesawPeripheral_run();
+}


### PR DESCRIPTION
Initial pass at adding UART.

See `examples/example_uart` for basic firmware sketch.

Tested with an ATtiny816 breakout connected to a QT PY RP2040 running loopback sketch:
https://github.com/adafruit/Adafruit_Seesaw/blob/master/examples/communication/UART_loopback/UART_loopback.ino