### PR TITLE
Change PWM to use TCA0

### DIFF
--- a/Adafruit_seesawPeripheral.h
+++ b/Adafruit_seesawPeripheral.h
@@ -143,9 +143,8 @@ uint16_t DATE_CODE = 0;
 #define ALL_GPIO                                                               \
   0x1FFFFFUL // this is chip dependant, for 817 we have 21 GPIO avail (0~20 inc)
 #define ALL_ADC 0b1111000000110011001111 // pins that have ADC capability
-#define ALL_PWM                                                                \
-  ((1UL << 0) | (1UL << 1) | (1UL << 9) | (1UL << 10) | (1UL << 11) |          \
-   (1UL << 12) | (1UL << 13) | (1UL << 10))
+#define ALL_PWM ((1UL << 6) | (1UL << 7) | (1UL << 8))  // alternate TCA0 WOx
+#define PWM_WO_OFFSET (6)
 #endif
 
 #if defined(ARDUINO_AVR_ATtiny816) || defined(ARDUINO_AVR_ATtiny806) ||        \
@@ -154,9 +153,8 @@ uint16_t DATE_CODE = 0;
 #define ALL_GPIO                                                               \
   0x01FFFFUL // this is chip dependant, for 816 we have 17 GPIO avail
 #define ALL_ADC 0b11100001100111111 // pins that have ADC capability
-#define ALL_PWM                                                                \
-  ((1UL << 0) | (1UL << 1) | (1UL << 7) | (1UL << 8) | (1UL << 9) |            \
-   (1UL << 10) | (1UL << 11) | (1UL << 16))
+#define ALL_PWM ((1UL << 4) | (1UL << 5) | (1UL << 6))  // alternate TCA0 WOx
+#define PWM_WO_OFFSET (4)
 #endif
 
 #define INVALID_GPIO ((1UL << SDA) | (1UL << SCL) | \
@@ -383,6 +381,13 @@ void Adafruit_seesawPeripheral_reset(void) {
 #endif
 #if CONFIG_PWM
   g_pwmStatus = 0;
+  // TCA0 is used for PWM support
+  takeOverTCA0();
+  PORTMUX.CTRLC |= 0b111;    // Alternate WOx output pin locations
+  TCA0.SINGLE.PER = 0xFFFF;  // Set TOP to MAX
+  TCA0.SINGLE.CTRLB = 0x03;  // Single-slope PWM, WG outputs off
+  TCA0.SINGLE.CTRLD = 0x00;  // Disable Split Mode
+  TCA0.SINGLE.CTRLA = 0x01;  // Enable TCA0 peripheral
 #endif
 #if CONFIG_NEOPIXEL
   for (uint16_t i = 0; i < CONFIG_NEOPIXEL_BUF_MAX; i++) {


### PR DESCRIPTION
**BREAKING CHANGE** - The pins that support PWM have changed

This PR changes the PWM support from using calls to the Arduino API  functions `analogWrite()` and `tone()` to using the TCA0 peripheral directly via its waveform generation output. This update will allow generating the necessary PWM output for controlling hobby servos for fixing #7.

**16 bit PWM is supported on 3 pins** - `WO0`, `WO1`, and `WO2` (alternate locations): 

![ATtiny_pinmux](https://github.com/adafruit/Adafruit_seesawPeripheral/assets/8755041/941b0dab-c6dc-44ee-80b3-cb881e5a3c7d)

The Arduino and CircuitPython seesaw libraries will need updating to match the new pins.

The CircuitPython library also has a bug:
https://github.com/adafruit/Adafruit_CircuitPython_seesaw/issues/116

Tested via the CircuitPython seesaw library (locally patched to fix issue above) and manually hacking to set PWM pins. QT Py RP2040 with ATtiny dev breakout(s) connect via STEMMA QT cable.

```python
import board
from adafruit_seesaw import seesaw, pwmout

ss = seesaw.Seesaw(board.STEMMA_I2C())

#--| HACK |-------------------
TINYX6_PWM_PINS = (4, 5, 6)
TINYX7_PWM_PINS = (6, 7, 8)
ss.pin_mapping.pwm_pins = TINYX6_PWM_PINS
#-----------------------------
 
pwm1 = pwmout.PWMOut(ss, 4)
pwm2 = pwmout.PWMOut(ss, 5)
pwm3 = pwmout.PWMOut(ss, 6)

pwm1.frequency = 50

pwm1.duty_cycle = int(0.1 * 0xFFFF)
pwm2.duty_cycle = int(0.5 * 0xFFFF)
pwm3.duty_cycle = int(0.8 * 0xFFFF)
```

**ATtiny816 output:**
![scope_t816](https://github.com/adafruit/Adafruit_seesawPeripheral/assets/8755041/957d739c-0fee-4a20-b064-9c7f5711e7ea)

**ATtiny817 output:**
![scope_t817](https://github.com/adafruit/Adafruit_seesawPeripheral/assets/8755041/63dbcd07-99b6-49ec-a697-5840e7257e10)

**ATtiny1616 output:**
![scope_t1616](https://github.com/adafruit/Adafruit_seesawPeripheral/assets/8755041/7d03e250-26d4-4c5b-8a31-58c6b7eed985)


