### PR TITLE
Update preproc logic for HW ID

### DIFF
--- a/Adafruit_seesawPeripheral_request.h
+++ b/Adafruit_seesawPeripheral_request.h
@@ -1,9 +1,15 @@
-#if defined(ARDUINO_AVR_ATtiny816)
+#if defined(ARDUINO_AVR_ATtiny806)
+#define SEESAW_HW_ID 0x84
+#elif defined(ARDUINO_AVR_ATtiny807)
+#define SEESAW_HW_ID 0x85
+#elif defined(ARDUINO_AVR_ATtiny816)
 #define SEESAW_HW_ID 0x86
 #elif defined(ARDUINO_AVR_ATtiny817)
 #define SEESAW_HW_ID 0x87
 #elif defined(ARDUINO_AVR_ATtiny1616)
 #define SEESAW_HW_ID 0x88
+#elif defined(ARDUINO_AVR_ATtiny1617)
+#define SEESAW_HW_ID 0x89
 #else
 #error "Unsupported chip variant selected"
 #endif

--- a/Adafruit_seesawPeripheral_request.h
+++ b/Adafruit_seesawPeripheral_request.h
@@ -1,4 +1,13 @@
-#define SEESAW_HW_ID_CODE_TINY8x7 0x87
+#if defined(ARDUINO_AVR_ATtiny816)
+#define SEESAW_HW_ID 0x86
+#elif defined(ARDUINO_AVR_ATtiny817)
+#define SEESAW_HW_ID 0x87
+#elif defined(ARDUINO_AVR_ATtiny1616)
+#define SEESAW_HW_ID 0x88
+#else
+#error "Unsupported chip variant selected"
+#endif
+
 extern volatile uint32_t g_bufferedBulkGPIORead;
 
 /***************************** data read */
@@ -9,7 +18,7 @@ void requestEvent(void) {
 
   if (base_cmd == SEESAW_STATUS_BASE) {
     if (module_cmd == SEESAW_STATUS_HW_ID) {
-      Wire.write(SEESAW_HW_ID_CODE_TINY8x7); // instant reply
+      Wire.write(SEESAW_HW_ID); // instant reply
     }
     if (module_cmd == SEESAW_STATUS_VERSION) {
       Adafruit_seesawPeripheral_write32(CONFIG_VERSION | DATE_CODE); // instant reply


### PR DESCRIPTION
Updates preprocessor logic to add unique IDs for each supported ATtiny 1-series chip variant (currently 816, 817, and 1616). Throws an error to stop compilation if any other variant selected.

**Only compile tested**. Compiles for selections of 816, 817, and 1616. Fails for others.
![image](https://github.com/adafruit/Adafruit_seesawPeripheral/assets/8755041/abcd7ef0-8b1f-4241-b41b-9ccaef88ef3d)

 `0x55` is the HW ID for SAMD.

`0x87` is the HW ID used previously for all ATtiny builds, but was intended for 817 only. The new values `0x86` for 816 and `0x88` for 1616 can be changed at this time if wanted.
