### PR TITLE
Add preproc options for PWM mode

### DIFF
--- a/Adafruit_seesawPeripheral.h
+++ b/Adafruit_seesawPeripheral.h
@@ -143,7 +143,13 @@ uint16_t DATE_CODE = 0;
 #define ALL_GPIO                                                               \
   0x1FFFFFUL // this is chip dependant, for 817 we have 21 GPIO avail (0~20 inc)
 #define ALL_ADC 0b1111000000110011001111 // pins that have ADC capability
+#ifdef CONFIG_PWM_16BIT
 #define ALL_PWM ((1UL << 6) | (1UL << 7) | (1UL << 8))  // alternate TCA0 WOx
+#else
+#define ALL_PWM                                                                \
+  ((1UL << 0) | (1UL << 1) | (1UL << 9) | (1UL << 10) | (1UL << 11) |          \
+   (1UL << 12) | (1UL << 13) | (1UL << 10))
+#endif
 #define PWM_WO_OFFSET (6)
 #endif
 
@@ -153,7 +159,13 @@ uint16_t DATE_CODE = 0;
 #define ALL_GPIO                                                               \
   0x01FFFFUL // this is chip dependant, for 816 we have 17 GPIO avail
 #define ALL_ADC 0b11100001100111111 // pins that have ADC capability
+#ifdef CONFIG_PWM_16BIT
 #define ALL_PWM ((1UL << 4) | (1UL << 5) | (1UL << 6))  // alternate TCA0 WOx
+#else
+#define ALL_PWM                                                                \
+  ((1UL << 0) | (1UL << 1) | (1UL << 7) | (1UL << 8) | (1UL << 9) |            \
+   (1UL << 10) | (1UL << 11) | (1UL << 16))
+#endif
 #define PWM_WO_OFFSET (4)
 #endif
 
@@ -197,7 +209,7 @@ volatile uint8_t IRQ_debounce_cntr = 0;
 #if CONFIG_ADC
 volatile uint8_t g_adcStatus = 0;
 #endif
-#if CONFIG_PWM
+#if (CONFIG_PWM | CONFIG_PWM_16BIT)
 volatile uint8_t g_pwmStatus = 0;
 #endif
 #if CONFIG_NEOPIXEL
@@ -381,7 +393,10 @@ void Adafruit_seesawPeripheral_reset(void) {
 #endif
 #if CONFIG_PWM
   g_pwmStatus = 0;
-  // TCA0 is used for PWM support
+  // PWM is provided by BSP's analogWrite() and tone()
+#elif CONFIG_PWM_16BIT
+  g_pwmStatus = 0;
+  // TCA0 is used for 16 bit PWM support
   takeOverTCA0();
   PORTMUX.CTRLC |= 0b111;    // Alternate WOx output pin locations
   TCA0.SINGLE.PER = 0xFFFF;  // Set TOP to MAX


### PR DESCRIPTION
This PR adds preprocessor logic to allow the 16 bit PWM support via TCA0 use to be optional. The previous PWM support based on the megatinycore's built in `analogWrite()` and `tone()` can also be used if desired.

The `#def` options that can be added to a firmware sketch are (**pick one**):
* `CONFIG_PWM` - use `analogWrite()` and `tone()` for 8 bit "PWM" on several pins (original support)
* `CONFIG_PWM_16BIT` - use TCA0 to provide 16 bit PWM on a limited set of pins (3 total)

Note that in addition to being limited to 8 bit resolution, the `CONFIG_PWM` option does **NOT** allow for separate control of frequency and duty cycle. This prevents hobby servos from being supported, since the required wave pattern can not be generated.

Tested using an ATtiny816 connected to a QT PY RP2040.

## CONFIG_PWM TEST
With a firmware build using `CONFIG_PWM` loaded onto ATtiny816, the following code:
```python
Adafruit CircuitPython 7.3.3 on 2022-08-29; Adafruit QT Py RP2040 with rp2040
>>> import board
>>> from adafruit_seesaw import seesaw, pwmout
>>> ss = seesaw.Seesaw(board.STEMMA_I2C())
>>> pwm = pwmout.PWMOut(ss, 0)
>>> pwm.frequency = 50
```
results in the expected 50Hz 50% duty cycle wave output from `tone()`:
![freq_8bit](https://github.com/adafruit/Adafruit_seesawPeripheral/assets/8755041/c6bfc22a-4f50-428b-8a8c-3ab7b3d62fa2)
and then setting duty cycle:
```python
>>> pwm.duty_cycle = int(0.2 * 2**16)
```
results in the expected 20% duty cycle at a frequency determined by the BSP from `analogWrite()`:
![duty_8bit](https://github.com/adafruit/Adafruit_seesawPeripheral/assets/8755041/28cfbdf7-f23c-4586-b6cd-e94054ad9423)

## CONFIG_PWM_16BIT
Using the same firmware, but built with `CONFIG_PWM_16BIT` set, the following code:
```python
Adafruit CircuitPython 7.3.3 on 2022-08-29; Adafruit QT Py RP2040 with rp2040
>>> import board
>>> from adafruit_seesaw import seesaw, pwmout
>>> ss = seesaw.Seesaw(board.STEMMA_I2C())
>>> pwm = pwmout.PWMOut(ss, 4)
>>> pwm.frequency = 50
>>> pwm.duty_cycle = int(0.2 * 2**16)
```
results in the expected 20% duty cycle of a 50Hz wave:
![freqduty_16bit](https://github.com/adafruit/Adafruit_seesawPeripheral/assets/8755041/3a61c803-1d66-42b4-b6f7-eab1eac7a4cb)

