### PR TITLE
Add support for setting encoder position

### DIFF
--- a/Adafruit_seesawPeripheral_receive.h
+++ b/Adafruit_seesawPeripheral_receive.h
@@ -295,7 +295,7 @@ void receiveEvent(int howMany) {
       }
     }
     else if ((module_cmd & 0xF0) ==  SEESAW_ENCODER_POSITION) {
-      if (howMany == 6) {
+      if (howMany == 6) { 
       encoder_num = module_cmd & 0x0F;
         if (encoder_num < CONFIG_NUM_ENCODERS){
           uint32_t value = i2c_buffer[2];

--- a/Adafruit_seesawPeripheral_receive.h
+++ b/Adafruit_seesawPeripheral_receive.h
@@ -294,6 +294,21 @@ void receiveEvent(int howMany) {
         }
       }
     }
+    else if ((module_cmd & 0xF0) ==  SEESAW_ENCODER_POSITION) {
+      if (howMany == 6) {
+      encoder_num = module_cmd & 0x0F;
+        if (encoder_num < CONFIG_NUM_ENCODERS){
+          uint32_t value = i2c_buffer[2];
+          value <<= 8;
+          value |= i2c_buffer[3];
+          value <<= 8;
+          value |= i2c_buffer[4];
+          value <<=8;
+          value |= i2c_buffer[5];
+          g_enc_value[encoder_num] = value;
+        }
+      }
+    }
   }
 #endif
 


### PR DESCRIPTION
For #20. Implements setting encoder position.

Tested with a [PID 5752](https://www.adafruit.com/product/5752) and QT PY RP2040 running CP.

**BEFORE**
```python
Adafruit CircuitPython 8.2.2 on 2023-07-31; Adafruit QT Py RP2040 with rp2040
>>> import board
>>> from adafruit_seesaw.seesaw import Seesaw
>>> i2c = board.STEMMA_I2C()
>>> ss = Seesaw(i2c, addr=73)
>>> for i in range(4):
...     print(ss.encoder_position(i))
... 
-11
-11
8
10
>>> for i in range(4):
...     ss.set_encoder_position(2342, i)
... 
>>> for i in range(4):
...     print(ss.encoder_position(i))
... 
-11
-11
8
10
>>>

```

**AFTER**
```python
Adafruit CircuitPython 8.2.2 on 2023-07-31; Adafruit QT Py RP2040 with rp2040
>>> import board
>>> from adafruit_seesaw.seesaw import Seesaw
>>> i2c = board.STEMMA_I2C()
>>> ss = Seesaw(i2c, addr=73)
>>> for i in range(4):
...     print(ss.encoder_position(i))
... 
5
-7
1
15
>>> for i in range(4):
...     ss.set_encoder_position(2342, i)
... 
>>> for i in range(4):
...     print(ss.encoder_position(i))
... 
2342
2342
2342
2342
>>>
```