### PR TITLE
Add soil module

### DIFF
--- a/Adafruit_seesawPeripheral.h
+++ b/Adafruit_seesawPeripheral.h
@@ -266,6 +266,14 @@ volatile uint8_t g_enc_flags[CONFIG_NUM_ENCODERS];
 
 #endif
 
+#if CONFIG_SOIL
+volatile uint32_t g_soil_update_delay = 5000;                  // milliseconds
+volatile uint16_t g_soil_value[CONFIG_NUM_SOIL] = {0};         // microseconds
+volatile uint8_t g_soil_samples[CONFIG_NUM_SOIL] = {10};       // unitless sample count
+volatile uint8_t g_soil_xdelay[CONFIG_NUM_SOIL] = {10};        // unitless multiplier
+volatile uint16_t g_soil_timeout[CONFIG_NUM_SOIL] = {0xFFFF};  // microseconds
+#endif
+
 /****************************************************** code */
 
 // global address
@@ -489,6 +497,29 @@ void Adafruit_seesawPeripheral_reset(void) {
   ADC0.SAMPCTRL = 12; // Add to usu. 13 ADC cycles for 25 cycles/sample
   ADC0.INTCTRL |= ADC_RESRDY_bm; // Enable result-ready interrupt
   ADC0.COMMAND |= ADC_STCONV_bm; // Start free-run conversion
+#endif
+
+#if CONFIG_SOIL
+#if defined(CONFIG_SOIL0_EXC_PIN) && defined(CONFIG_SOIL0_SEN_PIN)
+  pinMode(CONFIG_SOIL0_EXC_PIN, OUTPUT);
+  digitalWrite(CONFIG_SOIL0_EXC_PIN, LOW);
+  pinMode(CONFIG_SOIL0_SEN_PIN, INPUT);
+#endif
+#if defined(CONFIG_SOIL1_EXC_PIN) && defined(CONFIG_SOIL1_SEN_PIN)
+  pinMode(CONFIG_SOIL1_EXC_PIN, OUTPUT);
+  digitalWrite(CONFIG_SOIL1_EXC_PIN, LOW);
+  pinMode(CONFIG_SOIL1_SEN_PIN, INPUT);
+#endif
+#if defined(CONFIG_SOIL2_EXC_PIN) && defined(CONFIG_SOIL2_SEN_PIN)
+  pinMode(CONFIG_SOIL2_EXC_PIN, OUTPUT);
+  digitalWrite(CONFIG_SOIL2_EXC_PIN, LOW);
+  pinMode(CONFIG_SOIL2_SEN_PIN, INPUT);
+#endif
+#if defined(CONFIG_SOIL3_EXC_PIN) && defined(CONFIG_SOIL3_SEN_PIN)
+  pinMode(CONFIG_SOIL3_EXC_PIN, OUTPUT);
+  digitalWrite(CONFIG_SOIL3_EXC_PIN, LOW);
+  pinMode(CONFIG_SOIL3_SEN_PIN, INPUT);
+#endif
 #endif
 
 #if CONFIG_UART

--- a/Adafruit_seesawPeripheral_main.h
+++ b/Adafruit_seesawPeripheral_main.h
@@ -218,6 +218,81 @@ void Adafruit_seesawPeripheral_run(void) {
   TWI0.SCTRLA |= TWI_DIEN_bm | TWI_APIEN_bm | TWI_PIEN_bm;
 #endif // end CONFIG_FHT
 
+// Update soil readings
+#if CONFIG_SOIL
+  static uint32_t last_soil = 0;
+  uint32_t now_soil = millis();
+  if (now_soil - last_soil > g_soil_update_delay) {
+    for (uint8_t s = 0; s < CONFIG_NUM_SOIL; s++) {
+      if ((g_soil_samples[s] == 0)) continue;
+      unsigned long t1, t2;
+      unsigned long sum;
+      int epin, spin;
+      bool timeout;
+      // configure pins
+      switch(s) {
+#if defined(CONFIG_SOIL0_EXC_PIN) && defined(CONFIG_SOIL0_SEN_PIN)
+        case 0:
+          epin = CONFIG_SOIL0_EXC_PIN;
+          spin = CONFIG_SOIL0_SEN_PIN;
+          break;
+#endif
+#if defined(CONFIG_SOIL1_EXC_PIN) && defined(CONFIG_SOIL1_SEN_PIN)
+        case 1:
+          epin = CONFIG_SOIL1_EXC_PIN;
+          spin = CONFIG_SOIL1_SEN_PIN;
+          break;
+#endif
+#if defined(CONFIG_SOIL2_EXC_PIN) && defined(CONFIG_SOIL2_SEN_PIN)
+        case 2:
+          epin = CONFIG_SOIL2_EXC_PIN;
+          spin = CONFIG_SOIL2_SEN_PIN;
+          break;
+#endif
+#if defined(CONFIG_SOIL3_EXC_PIN) && defined(CONFIG_SOIL3_SEN_PIN)
+        case 3:
+          epin = CONFIG_SOIL3_EXC_PIN;
+          spin = CONFIG_SOIL3_SEN_PIN;
+          break;
+#endif
+        default:
+          continue;
+      }
+      // perform reading
+      sum = 0;
+      timeout = false;
+      for (uint8_t n = 0; n < g_soil_samples[s]; n++) {
+        // record charge time
+        t1 = micros();
+        digitalWrite(epin, HIGH);
+        while (!digitalRead(spin)) {
+          if ((micros() - t1) > g_soil_timeout[s]) {
+            timeout = true;
+            break;
+          }
+        }
+        t2 = micros();
+        // discharge
+        digitalWrite(epin, LOW);
+        delayMicroseconds(g_soil_xdelay[s] * (t2 - t1));
+        // sum the deltas
+        sum += t2 - t1;
+        // give up if timed out
+        if (timeout) break;
+      }
+      // store value, 0xFFFF = timed out
+      if (timeout) {
+        g_soil_value[s] = 0xFFFF;
+      } else {
+        sum /= g_soil_samples[s];
+        if (sum == 0xFFFF) sum -= 1;
+        g_soil_value[s] = uint16_t(sum);
+      }
+    }
+    last_soil = now_soil;
+  }
+#endif
+
 #if CONFIG_UART
   if (g_uart_inten) {
     if (CONFIG_UART_SERCOM.available()) {

--- a/Adafruit_seesawPeripheral_receive.h
+++ b/Adafruit_seesawPeripheral_receive.h
@@ -399,4 +399,37 @@ void receiveEvent(int howMany) {
     }
   }
 #endif
+
+#if CONFIG_SOIL
+  else if (base_cmd == SEESAW_SOIL_BASE) {
+    uint8_t soil_num = 0;
+    if ((module_cmd == SEESAW_SOIL_RATE) && (howMany == 6)) {
+      g_soil_update_delay =
+        uint32_t(i2c_buffer[2]) << 24 |
+        uint32_t(i2c_buffer[3]) << 16 |
+        uint32_t(i2c_buffer[4]) << 8  |
+        i2c_buffer[5];
+    }
+    else if (((module_cmd & 0xF0) == SEESAW_SOIL_SAMPLES) && (howMany == 3)) {
+      soil_num = module_cmd & 0x0F;
+      if (soil_num < CONFIG_NUM_SOIL) {
+        g_soil_samples[soil_num] = i2c_buffer[2];
+      }
+    }
+    else if (((module_cmd & 0xF0) == SEESAW_SOIL_XDELAY) && (howMany == 3)) {
+      soil_num = module_cmd & 0x0F;
+      if (soil_num < CONFIG_NUM_SOIL) {
+        g_soil_xdelay[soil_num] = i2c_buffer[2];
+      }
+    }
+    else if (((module_cmd & 0xF0) == SEESAW_SOIL_TIMEOUT) && (howMany == 4)) {
+      soil_num = module_cmd & 0x0F;
+      if (soil_num < CONFIG_NUM_SOIL) {
+        g_soil_timeout[soil_num] =
+          uint16_t(i2c_buffer[2]) << 8 |
+          i2c_buffer[3];
+      }
+    }
+  }
+#endif
 }

--- a/Adafruit_seesawPeripheral_request.h
+++ b/Adafruit_seesawPeripheral_request.h
@@ -105,6 +105,41 @@ void requestEvent(void) {
   }
 #endif
 
+#if CONFIG_SOIL
+  else if (base_cmd == SEESAW_SOIL_BASE) {
+    uint8_t soil_num = 0;
+    if (module_cmd == SEESAW_SOIL_RATE) {
+      Adafruit_seesawPeripheral_write32(g_soil_update_delay);
+    }
+    else if ((module_cmd & 0xF0) == SEESAW_SOIL_VALUE) {
+      soil_num = module_cmd & 0x0F;
+      if (soil_num < CONFIG_NUM_SOIL) {
+        Wire.write(g_soil_value[soil_num] >> 8);
+        Wire.write(g_soil_value[soil_num]);
+      }
+    }
+    else if ((module_cmd & 0xF0) == SEESAW_SOIL_SAMPLES) {
+      soil_num =  module_cmd & 0x0F;
+      if (soil_num < CONFIG_NUM_SOIL) {
+        Wire.write(g_soil_samples[soil_num]);
+      }
+    }
+    else if ((module_cmd & 0xF0) == SEESAW_SOIL_XDELAY) {
+      soil_num =  module_cmd & 0x0F;
+      if (soil_num < CONFIG_NUM_SOIL) {
+        Wire.write(g_soil_xdelay[soil_num]);
+      }
+    }
+    else if ((module_cmd & 0xF0) == SEESAW_SOIL_TIMEOUT) {
+      soil_num =  module_cmd & 0x0F;
+      if (soil_num < CONFIG_NUM_SOIL) {
+        Wire.write(g_soil_timeout[soil_num] >> 8);
+        Wire.write(g_soil_timeout[soil_num]);
+      }
+    }
+  }
+#endif
+
 #if CONFIG_UART
   else if (base_cmd == SEESAW_SERCOM0_BASE) {
     if (module_cmd == SEESAW_SERCOM_STATUS) {

--- a/examples/example_soil/example_soil.ino
+++ b/examples/example_soil/example_soil.ino
@@ -1,0 +1,44 @@
+#define PRODUCT_CODE            1234
+#define CONFIG_I2C_PERIPH_ADDR  0x42
+//#define CONFIG_UART_DEBUG         1
+
+#define CONFIG_INTERRUPT_PIN       13
+//#define USE_PINCHANGE_INTERRUPT   1
+
+// Can have up to 8 addresses
+#define CONFIG_ADDR_0_PIN          10
+#define CONFIG_ADDR_1_PIN          11
+#define CONFIG_ADDR_2_PIN          12
+
+//#define CONFIG_ADC                 1
+//#define CONFIG_PWM                 1
+#define CONFIG_NEOPIXEL            1
+#define CONFIG_NEOPIXEL_BUF_MAX   (1*3) // 1 pixel == 3 bytes
+
+//* ============== SOIL =================== *//
+#define CONFIG_SOIL                  1
+#define CONFIG_NUM_SOIL              1
+#define CONFIG_SOIL0_EXC_PIN         0
+#define CONFIG_SOIL0_SEN_PIN         1
+// #define CONFIG_SOIL1_EXC_PIN         2
+// #define CONFIG_SOIL1_SEN_PIN         3
+// #define CONFIG_SOIL2_EXC_PIN         4
+// #define CONFIG_SOIL2_SEN_PIN         5
+// #define CONFIG_SOIL3_EXC_PIN         6
+// #define CONFIG_SOIL3_SEN_PIN         7
+
+#include "Adafruit_seesawPeripheral.h"
+
+void setup() {
+#if CONFIG_UART_DEBUG
+  Serial.begin(115200);
+  delay(500);
+#endif
+  delay(1);
+  Adafruit_seesawPeripheral_begin();
+}
+
+
+void loop() {
+  Adafruit_seesawPeripheral_run();
+}


### PR DESCRIPTION
Adds support for RC timing based soil moisture sensing. Up to four sensors are supported. Each requires two digital IO pins.